### PR TITLE
Update for 1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,17 +18,17 @@
             <url>http://ess.ementalo.com/nexus/content/repositories/emen</url>
         </repository>
         <repository>
-            <id>bukkit-repo</id>
-            <url>http://repo.bukkit.org/content/repositories/releases/</url>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
     </repositories>
 
 
     <dependencies>
         <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>1.7.9-R0.2</version>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.12-R0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <build>
@@ -49,8 +49,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.0.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ementalo</groupId>
     <artifactId>TeleConfirmLite</artifactId>
-    <version>2.1.3</version>
+    <version>2.1.4</version>
     <description>Player to player teleport requests</description>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/com/ementalo/tcl/Metrics.java
+++ b/src/com/ementalo/tcl/Metrics.java
@@ -355,7 +355,7 @@ public final class Metrics {
         boolean onlineMode = Bukkit.getServer().getOnlineMode(); // TRUE if online mode is enabled
         String pluginVersion = description.getVersion();
         String serverVersion = Bukkit.getVersion();
-        int playersOnline = Bukkit.getServer().getOnlinePlayers().length;
+        int playersOnline = Bukkit.getServer().getOnlinePlayers().size();
 
         // END server software specific section -- all code below does not use any code outside of this class / Java
 


### PR DESCRIPTION
1) Increase version to 2.1.4
2) Update to build with java 8 (Base minecraft code now compiles against java 8)
3) Update repo and dependency to build against spigot 1.12
4) Minor correction to removed method (`getOnlinePlayers().length;` changed to `getOnlinePlayers().size();`)